### PR TITLE
Add changelog entry for OAuth 2 blank redirect URL impactful change

### DIFF
--- a/content/2020/07-30-updates-to-search-relevance-performance.md
+++ b/content/2020/07-30-updates-to-search-relevance-performance.md
@@ -26,4 +26,4 @@ information on how to search using Box's API.
 
 [wiki-stop-words]: https://en.wikipedia.org/wiki/Stop_words
 [wiki-tokenizer]: https://en.wikipedia.org/wiki/Lexical_analysis#Tokenization
-[search_guide]: g://search/full-text-search
+[search_guide]: g://search/

--- a/content/2020/09-29-changes-to-oauth-2-app-redirect-url-requirements.md
+++ b/content/2020/09-29-changes-to-oauth-2-app-redirect-url-requirements.md
@@ -10,38 +10,39 @@ show_excerpt: true
 release_source_url: ''
 ---
 
-# Changes to OAuth 2 app redirect URL requirements
+# Change to OAuth 2 app redirect URI requirements
 
 On October 29th, 2020, Box will begin employing stricter requirements for
-redirect URLs used within new and existing
-[OAuth 2](g://authentication/oauth2/) based Box integrations that may affect
+redirect URIs used within new and existing
+[OAuth 2](g://authentication/oauth2/)-based Box integrations that may affect
 your application.
 
-Existing application owners that currently use a blank redirect URL in their
+Existing application owners that currently use a blank redirect URI in their
 application configuration, as
 [described here](g://applications/custom-apps/oauth2-setup/#redirect-uri), will
-need to update the redirect URL to match the redirect used within the code
+need to update the redirect URI to match the redirect used within the code
 redirect step,
 [described here](g://authentication/oauth2/with-sdk/#2-redirect-user). 
 
-On October 29th, 2020, applications that are still configured with a blank URL
+On October 29th, 2020, applications that are still configured with a blank URI
 will begin returning an error when the user is redirected back to your
-application if URL adjustments aren't made.
+application if URI adjustments aren't made.
 
 All impacted application owners and collaborators have been notified via
 the email address associated with their developer account.
 
 ## How to validate and make the change
-To validate your redirect URL and update your application(s) if they are
+To validate your redirect URI and update your application(s) if they are
 affected, take the following steps:
 
 * Go to the
  [Box developer console](https://cloud.app.box.com/developers/console) as the
  user who owns the application(s).
-* For each OAuth 2 application, click on the application to open it.
-* From the left navigation, click on "Configuration".
-* Scroll down to the "OAuth 2.0 Redirect URI" section. 
-* For any application where this URL is blank, add the URL that is being used
+* For each **Custom App** using **OAuth 2** (client-side authentication) click
+ on the application to open it.
+* From the left navigation, click on **Configuration**.
+* Scroll down to the **OAuth 2.0 Redirect URI** section. 
+* For any application where this URI is blank, add the URI that is being used
  in the application code when redirecting the user back to your application
  from the Box auth step,
- [described here](g://authentication/oauth2/with-sdk/#2-redirect-user).
+ [as is described in this guide](g://authentication/oauth2/with-sdk/#2-redirect-user).

--- a/content/2020/09-29-changes-to-oauth-2-app-redirect-url-requirements.md
+++ b/content/2020/09-29-changes-to-oauth-2-app-redirect-url-requirements.md
@@ -1,0 +1,47 @@
+---
+applied_at: "2020-10-29"
+applies_to: 
+- api
+- sdks
+is_impactful: true
+is_new_feature: false
+collapse: true
+show_excerpt: true
+release_source_url: ''
+---
+
+# Changes to OAuth 2 app redirect URL requirements
+
+On October 29th, 2020, Box will begin employing stricter requirements for
+redirect URLs used within new and existing
+[OAuth 2](g://authentication/oauth2/) based Box integrations that may affect
+your application.
+
+Existing application owners that currently use a blank redirect URL in their
+application configuration, as
+[described here](g://applications/custom-apps/oauth2-setup/#redirect-uri), will
+need to update the redirect URL to match the redirect used within the code
+redirect step,
+[described here](g://authentication/oauth2/with-sdk/#2-redirect-user). 
+
+On October 29th, 2020, applications that are still configured with a blank URL
+will begin returning an error when the user is redirected back to your
+application if URL adjustments aren't made.
+
+All impacted application owners and collaborators have been notified via
+the email address associated with their developer account.
+
+## How to validate and make the change
+To validate your redirect URL and update your application(s) if they are
+affected, take the following steps:
+
+* Go to the
+ [Box developer console](https://cloud.app.box.com/developers/console) as the
+ user who owns the application(s).
+* For each OAuth 2 application, click on the applicationto open it.
+* From the left navigation, click on "Configuration".
+* Scroll down to the "OAuth 2.0 Redirect URI" section. 
+* For any application where this URL is blank, add the URL that is being used
+ in the application code when redirecting the user back to your application
+ from the Box auth step,
+ [described here](g://authentication/oauth2/with-sdk/#2-redirect-user).

--- a/content/2020/09-29-changes-to-oauth-2-app-redirect-url-requirements.md
+++ b/content/2020/09-29-changes-to-oauth-2-app-redirect-url-requirements.md
@@ -38,7 +38,7 @@ affected, take the following steps:
 * Go to the
  [Box developer console](https://cloud.app.box.com/developers/console) as the
  user who owns the application(s).
-* For each OAuth 2 application, click on the applicationto open it.
+* For each OAuth 2 application, click on the application to open it.
 * From the left navigation, click on "Configuration".
 * Scroll down to the "OAuth 2.0 Redirect URI" section. 
 * For any application where this URL is blank, add the URL that is being used


### PR DESCRIPTION
# Description

DO NOT PUSH BEFORE 9am PT SEPTEMBER 29th, 2020

Changelog entry for impactful change comms sent to app developers who are using a blank redirect URL in their OAuth 2 applications. 

Fixes # (issue)
Re `DDOC-373`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have run `yarn test` and `yarn lint` to make sure my changes pass all
  linters and tests
- [x] I have pulled the latest changes from the upstream developer branch