### PR TITLE
Add changelog entry for new type field in shared link search results

### DIFF
--- a/content/2020/12-03-new-type-field-in-search-api-responses.md
+++ b/content/2020/12-03-new-type-field-in-search-api-responses.md
@@ -1,0 +1,60 @@
+---
+applied_at: "2020-12-03"
+applies_to: 
+- api
+is_impactful: false
+is_new_feature: false
+collapse: true
+show_excerpt: true
+release_source_url: ''
+---
+
+# New `type` field in search API responses
+
+A new field, `type`, has been introduced in the
+[search result response object][search_result_shared_link] for returned shared
+link items.
+
+This response object format is only returned when making calls to the
+[content search][search_content] endpoint with the
+`include_recent_shared_links` query parameter set to `true`.
+
+There is no impact to existing applications that are currently consuming this
+response object.
+
+## Updates
+
+Prior to this release, the return object for shared link search results
+included two objects:
+
+* `accessible_via_shared_link`: The shared link which the item is accessible
+ from.
+* `item`: The file, folder, or web link that matched the search query.
+
+```js
+{
+  "accessible_via_shared_link": "https://www.box.com/s/vfejh7y01sb263wjtgfe",
+  "item": {
+    ...
+  }
+}
+```
+
+This update introduces the new `type` field, which is a string that will always
+be set to `search_result`.
+
+```js
+{
+  "type": "search_result",
+  "accessible_via_shared_link": "https://www.box.com/s/vfejh7y01sb263wjtgfe",
+  "item": {
+    ...
+  }
+}
+```
+
+For complete format information see the
+[shared link search result][search_result_shared_link] response object.
+
+[search_content]: r://get-search/
+[search_result_shared_link]: r://resources/search-result-with-shared-link/


### PR DESCRIPTION
# Description

Changelog entry for new `type` field in the response object for shared link search results.

Fixes `DDOC-394`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have run `yarn test` and `yarn lint` to make sure my changes pass all
  linters and tests
- [x] I have pulled the latest changes from the upstream developer branch

## Contribution guidelines

For contribution guidelines, styleguide, and other helpful information please
see the `CONTRIBUTING.md` file in the root of this project.