### PR TITLE
DDOC-574: Add a changelog entry for event params

### DIFF
--- a/content/2022/05-06-new-sign-events-payload-field.md
+++ b/content/2022/05-06-new-sign-events-payload-field.md
@@ -1,5 +1,5 @@
 ---
-applied_at: "2022-05-03"
+applied_at: "2022-05-06"
 applies_to: 
 - api
 is_impactful: true

--- a/content/2022/05-10-new-parameters-for-events.md
+++ b/content/2022/05-10-new-parameters-for-events.md
@@ -1,0 +1,30 @@
+---
+applied_at: "2022-05-10"
+applies_to: 
+- api
+is_impactful: true
+is_new_feature: true
+collapse: true
+show_excerpt: true
+release_source_url: ''
+---
+
+# New Parameters Added to Event API Reference
+
+The Event API now includes two new parameters:
+
+* `created_at` specifying the exact time an event was created
+* `recorded_at` specifying the time an event was registered in the database
+
+<!-- more -->
+
+## Updates
+* Added new parameters `created_at` and `recorded_at` to [Event API Reference][2].
+
+## Where to get support
+
+Should you have any issues or need further guidance, please post a request to
+our [developer forum][1] for any help needed.
+
+[1]: https://support.box.com/hc/en-us/community/topics/360001932973-Platform-and-Developer-Forum
+[2]: r://event

--- a/content/2022/05-10-new-parameters-for-events.md
+++ b/content/2022/05-10-new-parameters-for-events.md
@@ -13,8 +13,8 @@ release_source_url: ''
 
 The Event API now includes two new parameters:
 
-* `created_at` specifying the exact time an event was created
-* `recorded_at` specifying the time an event was registered in the database
+* `created_at` specifying when an event was created
+* `recorded_at` specifying when an event was registered in the database
 
 <!-- more -->
 

--- a/content/2022/05-11-new-fields-in-event-api-ref.md
+++ b/content/2022/05-11-new-fields-in-event-api-ref.md
@@ -19,7 +19,7 @@ The Event resource specification now includes two new fields:
 <!-- more -->
 
 ## Updates
-* Added new parameters `created_at` and `recorded_at` to the [Event] resource specification [2].
+* Added new fields `created_at` and `recorded_at` to the [Event] resource specification [2].
 
 ## Where to get support
 

--- a/content/2022/05-11-new-fields-in-event-api-ref.md
+++ b/content/2022/05-11-new-fields-in-event-api-ref.md
@@ -9,7 +9,7 @@ show_excerpt: true
 release_source_url: ''
 ---
 
-# New Parameters Added to Event Specification
+# New Fields Added to Event Specification
 
 The Event resource specification now includes two new fields:
 

--- a/content/2022/05-11-new-fields-in-event-api-ref.md
+++ b/content/2022/05-11-new-fields-in-event-api-ref.md
@@ -1,5 +1,5 @@
 ---
-applied_at: "2022-05-10"
+applied_at: "2022-05-11"
 applies_to: 
 - api
 is_impactful: true
@@ -9,9 +9,9 @@ show_excerpt: true
 release_source_url: ''
 ---
 
-# New Parameters Added to Event API Reference
+# New Parameters Added to Event Specification
 
-The Event API now includes two new parameters:
+The Event resource specification now includes two new fields:
 
 * `created_at` specifying when an event was created
 * `recorded_at` specifying when an event was registered in the database
@@ -19,7 +19,7 @@ The Event API now includes two new parameters:
 <!-- more -->
 
 ## Updates
-* Added new parameters `created_at` and `recorded_at` to [Event API Reference][2].
+* Added new parameters `created_at` and `recorded_at` to the [Event] resource specification [2].
 
 ## Where to get support
 


### PR DESCRIPTION
# Description

Added a changelog entry for event params: `created_at`, `recorded_at`

Fixes DDOC-574

