### PR TITLE
Add support section in changelog

### DIFF
--- a/content/2023/01-11-salesforce-toolkit-flow-actions.md
+++ b/content/2023/01-11-salesforce-toolkit-flow-actions.md
@@ -17,5 +17,11 @@ the [following methods][1]. It allows Box for Salesforce users to
 build automated solutions, such as folder structure, using
 [Salesforce Flows][2].
 
+## Where to get support
+
+Should you have any issues or need further guidance, please post a request to
+our [developer forum][3] for any help needed. 
+
 [1]: g://tooling/salesforce-toolkit/flow-actions
 [2]: https://help.salesforce.com/s/articleView?id=sf.flow.htm&type=5
+[3]: https://support.box.com/hc/en-us/community/topics/360001932973-Platform-and-Developer-Forum

--- a/content/2023/02-08-sample-code-catalog-released.md
+++ b/content/2023/02-08-sample-code-catalog-released.md
@@ -23,3 +23,10 @@ release_source_url: ''
 We are happy to announce that [the Sample Code Catalog](https://developer.box.com/sample-code/) `v1.0.0` 
 is now available on our Box Developer site. From now on you can browse 
 code samples in various programming languages and filter them by category.
+
+## Where to get support
+
+Should you have any issues or need further guidance, please post a request to
+our [developer forum][1] for any help needed. 
+
+[1]: https://support.box.com/hc/en-us/community/topics/360001932973-Platform-and-Developer-Forum

--- a/content/2023/02-23-multidoc-support-API-and-signer-attachments.md
+++ b/content/2023/02-23-multidoc-support-API-and-signer-attachments.md
@@ -21,6 +21,12 @@ supported in our [public API][2].
 The [signer attachments][3] feature allows users to request
 additional files from signers in a file attachment field.
 
+## Where to get support
+
+Should you have any issues or need further guidance, please post a request to
+our [developer forum][4] for any help needed. 
+
 [1]: https://support.box.com/hc/en-us/sections/10302887198227-Multiple-documents-in-a-signature-request
 [2]: e://post-sign-requests
 [3]: r://sign-request#param-signers-inputs-content_type
+[4]: https://support.box.com/hc/en-us/community/topics/360001932973-Platform-and-Developer-Forum


### PR DESCRIPTION
_Where to get support_ section is missing in a few of recent changelog entries, should be added to every entry.

Solves [DDOC-791](https://jira.inside-box.net/browse/DDOC-791)