### PR TITLE
Add google palm model deprecation notice

### DIFF
--- a/code/src/scripts/new-release-from-template.js
+++ b/code/src/scripts/new-release-from-template.js
@@ -57,7 +57,8 @@ const run = async () => {
         `sdks`,
         `guides`,
         `frontend`,
-        `ui-elements`
+        `ui-elements`,
+        `ai`
       ],
       validate: (list) => list.length > 0
     },

--- a/code/src/tests/checkFrontmatter.test.js
+++ b/code/src/tests/checkFrontmatter.test.js
@@ -52,7 +52,8 @@ files.forEach(source => {
       'guides',
       'other',
       'frontend',
-      'ui-elements'
+      'ui-elements',
+      'ai'
     ])
   })
 })

--- a/content/2025/01-09-google-palm-deprecation-and-removal.md
+++ b/content/2025/01-09-google-palm-deprecation-and-removal.md
@@ -1,0 +1,25 @@
+---
+applied_at: "2025-01-17"
+applies_to: 
+- ai
+is_impactful: true
+is_new_feature: false
+collapse: true
+show_excerpt: true
+release_source_url: ''
+---
+
+# `Google PaLM` deprecation and removal
+
+<!-- more -->
+
+`Google Pathways Language Models (PaLM)` are being deprecated by `Google`.
+
+As a result, the following models will be removed from Box AI on 2025-01-17
+* `text_bison`
+* `text_bison_32k`
+* `text_unicorn`
+* `google_text_embedding_gecko*`
+
+If you are using one of these models via agent override, check our [list of 
+supported models](https://developer.box.com/guides/box-ai/ai-agents/) here. 


### PR DESCRIPTION
# Description

Add a changelog entry to notify developers that the Google PaLM models are deprecated and will be removed on 2025-01-17

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own changes
- [x] I have run `yarn test` and `yarn lint` to make sure my changes pass all
  linters and tests
- [x] I have pulled the latest changes from the upstream developer branch

## Contribution guidelines

For contribution guidelines, styleguide, and other helpful information please
see the `CONTRIBUTING.md` file in the root of this project.
