### PR TITLE
Add Gemini 2.5 Pro; deprecate Gemini 2.5 Pro Preview and Gemini 2.5 Flash Preview

### DIFF
--- a/content/2025/07-27-new-model-deprecated-models.md
+++ b/content/2025/07-27-new-model-deprecated-models.md
@@ -1,0 +1,41 @@
+applied_at: "2025-07-27"
+applies_to:
+  - guides
+  - api
+  - ai
+is_impactful: true
+is_new_feature: true
+collapse: true
+show_excerpt: true
+release_source_url: ""
+---
+
+# Box AI API - Google Gemini 2.5 Pro now available; Gemini 2.5 Flash Preview and Gemini 2.5 Pro Preview deprecated
+
+The list of [available AI models][1] has been recently updated with Google Gemini 2.5 Pro.
+
+The following models have been deprecated:
+
+* Google Gemini 2.5 Flash Preview
+* Google Gemini 2.5 Pro Preview
+
+For more information, see [retired models][deprecated].
+
+Models offered in **Preview** mode have not been fully performance-tested at scale and are made available on an as-is basis. You may experience variability in model/output quality, availability, and accuracy.
+
+You can use the provided models to [override the default model][2] used in the AI agent configuration. 
+For further details on Box AI API, see the [guides][3] and [API reference][4].
+
+<!-- more -->
+
+
+## Where to get support
+
+Should you have any issues or need further guidance, please post a request to our [developer forum][5] for any help needed.
+
+[1]: https://developer.box.com/guides/box-ai/supported-models/
+[2]: https://box-ai/ai-agents/ai-agent-overrides
+[3]: https://developer.box.com/guides/box-ai
+[4]: https://developer.box.com/reference/post-ai-ask/
+[5]: https://forum.box.com/
+[deprecated]: https://cloud.google.com/vertex-ai/generative-ai/docs/learn/model-versions#expandable-1


### PR DESCRIPTION
1. Add Gemini 2.5 Pro.
2. Deprecate Gemini 2.5 Pro Preview and Gemini 2.5 Flash Preview.

Fixes [DDOC-1361](https://jira.inside-box.net/browse/DDOC-1361).

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own changes
- [ ] I have run `yarn test` and `yarn lint` to make sure my changes pass all
  linters and tests
- [ ] I have pulled the latest changes from the upstream developer branch

## Contribution guidelines

For contribution guidelines, styleguide, and other helpful information please
see the `CONTRIBUTING.md` file in the root of this project.
