### PR TITLE
Sync BUIE changelog entries to box-mintlify

### DIFF
--- a/.github/workflows/sync-mintlify.yml
+++ b/.github/workflows/sync-mintlify.yml
@@ -73,15 +73,15 @@ jobs:
           ENTRY_COUNT="$(jq '.entries | length' "$OUTPUT_JSON")"
           echo "entry_count=${ENTRY_COUNT}" >> "$GITHUB_OUTPUT"
           if [ "$ENTRY_COUNT" -eq 0 ]; then
-            echo "No eligible SDK changes detected, skipping commit and PR creation."
-            echo "sync_target=no eligible SDK changes" >> "$GITHUB_OUTPUT"
+            echo "No eligible changelog entries detected, skipping commit and PR creation."
+            echo "sync_target=no eligible changelog entries" >> "$GITHUB_OUTPUT"
             echo "pr_url=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           BRANCH_SUFFIX="$(jq -r '.branchSuffix' "$OUTPUT_JSON")"
           PR_TITLE="$(jq -r '.prTitle' "$OUTPUT_JSON")"
-          SYNC_TARGET="$(jq -r 'if (.entries | length) == 1 then "\(.entries[0].repoDisplayName) \(.entries[0].version)" else "\(.entries | length) SDK releases" end' "$OUTPUT_JSON")"
+          SYNC_TARGET="$(jq -r 'if (.entries | length) == 1 then "\(.entries[0].repoDisplayName) \(.entries[0].version)" else "\(.entries | length) release changelog entries" end' "$OUTPUT_JSON")"
           SUMMARY_LINES="$(jq -r '.entries[] | "- \(.repoDisplayName) \(.version) ([Release](\(.releaseUrl)))"' "$OUTPUT_JSON")"
           FILE_LINES="$(jq -r '.entries[] | "- `\(.filePath)` (new or updated snippet)"' "$OUTPUT_JSON")"
 

--- a/code/src/MintlifySync/changelog.js
+++ b/code/src/MintlifySync/changelog.js
@@ -98,13 +98,9 @@ function parseChangelogEntry({ content, contentPath = '' } = {}) {
     repoDisplayName,
     version
   }
-  const isMintlifySyncEligible = isMintlifySyncEligibleEntry(entry)
-  const isSdkRelease = isSdkReleaseEntry(entry)
-
   return {
     ...entry,
-    isMintlifySyncEligible,
-    isSdkRelease
+    isMintlifySyncEligible: isMintlifySyncEligibleEntry(entry)
   }
 }
 
@@ -113,15 +109,6 @@ function isMintlifySyncEligibleEntry(entry = {}) {
 
   return (
     (labels.includes('sdks') || labels.includes('ui-elements')) &&
-    hasRequiredReleaseFields(entry)
-  )
-}
-
-function isSdkReleaseEntry(entry = {}) {
-  const labels = normalizeLabels(entry.labels)
-
-  return (
-    labels.includes('sdks') &&
     hasRequiredReleaseFields(entry)
   )
 }

--- a/code/src/MintlifySync/changelog.js
+++ b/code/src/MintlifySync/changelog.js
@@ -5,7 +5,7 @@ const fs = require('fs-extra')
 const yaml = require('js-yaml')
 
 const FRONTMATTER_REGEX = /^---\r?\n([\s\S]*?)\r?\n---\r?\n*/
-const SDK_RELEASE_HEADING_REGEX = /^#\s+(.+?)\s+`([^`]+)`\s+released\s*$/m
+const RELEASE_HEADING_REGEX = /^#\s+(.+?)\s+`([^`]+)`\s+released\s*$/m
 
 function normalizeContentPaths(contentPaths) {
   if (Array.isArray(contentPaths)) {
@@ -59,7 +59,7 @@ async function loadEligibleChangelogEntries({ repoPath = process.cwd(), contentP
 
     const content = await fs.readFile(absolutePath, 'utf8')
     const entry = parseChangelogEntry({ content, contentPath })
-    if (entry.isSdkRelease) {
+    if (entry.isMintlifySyncEligible) {
       entries.push(entry)
     }
   }
@@ -79,7 +79,7 @@ function parseChangelogEntry({ content, contentPath = '' } = {}) {
 
   const frontmatter = yaml.load(frontmatterMatch[1]) || {}
   const markdown = content.slice(frontmatterMatch[0].length)
-  const headingMatch = markdown.match(SDK_RELEASE_HEADING_REGEX)
+  const headingMatch = markdown.match(RELEASE_HEADING_REGEX)
   const repoDisplayName = headingMatch ? headingMatch[1].trim() : ''
   const version = headingMatch ? headingMatch[2].trim() : ''
   const body = headingMatch
@@ -98,23 +98,47 @@ function parseChangelogEntry({ content, contentPath = '' } = {}) {
     repoDisplayName,
     version
   }
+  const isMintlifySyncEligible = isMintlifySyncEligibleEntry(entry)
+  const isSdkRelease = isSdkReleaseEntry(entry)
 
   return {
     ...entry,
-    isSdkRelease: isSdkReleaseEntry(entry)
+    isMintlifySyncEligible,
+    isSdkRelease
   }
 }
 
+function isMintlifySyncEligibleEntry(entry = {}) {
+  const labels = normalizeLabels(entry.labels)
+
+  return (
+    (labels.includes('sdks') || labels.includes('ui-elements')) &&
+    hasRequiredReleaseFields(entry)
+  )
+}
+
 function isSdkReleaseEntry(entry = {}) {
-  const labels = Array.isArray(entry.labels) ? entry.labels.map((label) => label.toLowerCase()) : []
+  const labels = normalizeLabels(entry.labels)
 
   return (
     labels.includes('sdks') &&
+    hasRequiredReleaseFields(entry)
+  )
+}
+
+function hasRequiredReleaseFields(entry = {}) {
+  return (
     typeof entry.repoDisplayName === 'string' &&
     entry.repoDisplayName.startsWith('Box ') &&
     Boolean(entry.version) &&
     Boolean(entry.releaseSourceUrl)
   )
+}
+
+function normalizeLabels(labels = []) {
+  return Array.isArray(labels)
+    ? labels.map((label) => String(label).trim().toLowerCase()).filter(Boolean)
+    : []
 }
 
 function sortEntriesForInsertion(entries = []) {
@@ -142,6 +166,7 @@ function isZeroSha(value) {
 }
 
 module.exports = {
+  isMintlifySyncEligibleEntry,
   loadEligibleChangelogEntries,
   normalizeContentPaths,
   parseChangelogEntry,

--- a/code/src/MintlifySync/converter.js
+++ b/code/src/MintlifySync/converter.js
@@ -67,6 +67,9 @@ function mapLabelsToTags({ labels, repoDisplayName }) {
       if (lower === 'ios' || (lower === 'swift' && String(repoDisplayName).toLowerCase().includes('ios'))) {
         return 'iOS'
       }
+      if (lower === 'ui-elements') {
+        return 'UI Elements'
+      }
       return lower.charAt(0).toUpperCase() + lower.slice(1)
     })
 }

--- a/code/src/MintlifySync/index.js
+++ b/code/src/MintlifySync/index.js
@@ -32,12 +32,12 @@ async function runMintlifySync() {
     repoPath: changelogRepoPath
   })
 
-  console.log(`[MintlifySync] Eligible SDK entries: ${changelogEntries.length}`)
+  console.log(`[MintlifySync] Eligible release entries: ${changelogEntries.length}`)
   if (changelogEntries.length === 0) {
     const output = buildWorkflowOutput([])
     console.log(`[MintlifySync] Writing workflow output: ${workflowOutputPath}`)
     await fs.outputFile(workflowOutputPath, JSON.stringify(output, null, 2))
-    console.log('[MintlifySync] No eligible SDK changelog entries found.')
+    console.log('[MintlifySync] No eligible changelog entries found.')
     return output
   }
 
@@ -100,7 +100,7 @@ function buildWorkflowOutput(entries = []) {
 
   const prTitle = normalizedEntries.length === 1
     ? `Add changelog: ${normalizedEntries[0].repoDisplayName} ${normalizedEntries[0].version}`
-    : `Add changelog entries: ${normalizedEntries.length} SDK releases`
+    : `Add changelog entries: ${normalizedEntries.length} release entries`
 
   return {
     branchSuffix: normalizedEntries.length === 1

--- a/code/src/MintlifySync/index.js
+++ b/code/src/MintlifySync/index.js
@@ -100,7 +100,7 @@ function buildWorkflowOutput(entries = []) {
 
   const prTitle = normalizedEntries.length === 1
     ? `Add changelog: ${normalizedEntries[0].repoDisplayName} ${normalizedEntries[0].version}`
-    : `Add changelog entries: ${normalizedEntries.length} release entries`
+    : `Add changelog entries: ${normalizedEntries.length} releases`
 
   return {
     branchSuffix: normalizedEntries.length === 1

--- a/code/tests/mintlifySync/changelog.test.js
+++ b/code/tests/mintlifySync/changelog.test.js
@@ -22,7 +22,7 @@ describe('Mintlify changelog parsing', () => {
         repoDisplayName: 'Box Java SDK',
         version: 'v10.7.0',
         labels: ['sdks', 'java'],
-        isSdkRelease: true
+        isMintlifySyncEligible: true
       },
       {
         contentPath: 'content/2026/04-01-box-java-sdk-v560-released.md',
@@ -30,7 +30,7 @@ describe('Mintlify changelog parsing', () => {
         repoDisplayName: 'Box Java SDK',
         version: 'v5.6.0',
         labels: ['sdks', 'java'],
-        isSdkRelease: true
+        isMintlifySyncEligible: true
       },
       {
         contentPath: 'content/2026/04-01-box-ios-sdk-1060-released.md',
@@ -38,7 +38,7 @@ describe('Mintlify changelog parsing', () => {
         repoDisplayName: 'Box iOS SDK',
         version: '10.6.0',
         labels: ['sdks', 'swift'],
-        isSdkRelease: true
+        isMintlifySyncEligible: true
       },
       {
         contentPath: 'content/2026/04-01-box-windows-sdk-v1080-released.md',
@@ -46,7 +46,7 @@ describe('Mintlify changelog parsing', () => {
         repoDisplayName: 'Box Windows SDK',
         version: 'v10.8.0',
         labels: ['sdks', 'dotnet'],
-        isSdkRelease: true
+        isMintlifySyncEligible: true
       },
       {
         contentPath: 'content/2026/01-05-box-ui-elements-v2600-released.md',
@@ -54,7 +54,7 @@ describe('Mintlify changelog parsing', () => {
         repoDisplayName: 'Box UI Elements',
         version: 'v26.0.0',
         labels: ['frontend', 'ui-elements'],
-        isSdkRelease: false
+        isMintlifySyncEligible: true
       }
     ]
 
@@ -65,8 +65,7 @@ describe('Mintlify changelog parsing', () => {
         contentPath: testCase.contentPath
       })
 
-      expect(entry.isMintlifySyncEligible).toBeTruthy()
-      expect(entry.isSdkRelease).toBe(testCase.isSdkRelease)
+      expect(entry.isMintlifySyncEligible).toBe(testCase.isMintlifySyncEligible)
       expect(entry.appliedAt).toBe(testCase.appliedAt)
       expect(entry.repoDisplayName).toBe(testCase.repoDisplayName)
       expect(entry.version).toBe(testCase.version)

--- a/code/tests/mintlifySync/changelog.test.js
+++ b/code/tests/mintlifySync/changelog.test.js
@@ -14,31 +14,47 @@ async function readChangelog(contentPath) {
 }
 
 describe('Mintlify changelog parsing', () => {
-  test('parses real merged SDK changelog files', async () => {
+  test('parses real merged release changelog files', async () => {
     const cases = [
       {
         contentPath: 'content/2026/04-01-box-java-sdk-v1070-released.md',
+        appliedAt: '2026-04-01',
         repoDisplayName: 'Box Java SDK',
         version: 'v10.7.0',
-        labels: ['sdks', 'java']
+        labels: ['sdks', 'java'],
+        isSdkRelease: true
       },
       {
         contentPath: 'content/2026/04-01-box-java-sdk-v560-released.md',
+        appliedAt: '2026-04-01',
         repoDisplayName: 'Box Java SDK',
         version: 'v5.6.0',
-        labels: ['sdks', 'java']
+        labels: ['sdks', 'java'],
+        isSdkRelease: true
       },
       {
         contentPath: 'content/2026/04-01-box-ios-sdk-1060-released.md',
+        appliedAt: '2026-04-01',
         repoDisplayName: 'Box iOS SDK',
         version: '10.6.0',
-        labels: ['sdks', 'swift']
+        labels: ['sdks', 'swift'],
+        isSdkRelease: true
       },
       {
         contentPath: 'content/2026/04-01-box-windows-sdk-v1080-released.md',
+        appliedAt: '2026-04-01',
         repoDisplayName: 'Box Windows SDK',
         version: 'v10.8.0',
-        labels: ['sdks', 'dotnet']
+        labels: ['sdks', 'dotnet'],
+        isSdkRelease: true
+      },
+      {
+        contentPath: 'content/2026/01-05-box-ui-elements-v2600-released.md',
+        appliedAt: '2026-01-05',
+        repoDisplayName: 'Box UI Elements',
+        version: 'v26.0.0',
+        labels: ['frontend', 'ui-elements'],
+        isSdkRelease: false
       }
     ]
 
@@ -49,20 +65,22 @@ describe('Mintlify changelog parsing', () => {
         contentPath: testCase.contentPath
       })
 
-      expect(entry.isSdkRelease).toBeTruthy()
-      expect(entry.appliedAt).toBe('2026-04-01')
+      expect(entry.isMintlifySyncEligible).toBeTruthy()
+      expect(entry.isSdkRelease).toBe(testCase.isSdkRelease)
+      expect(entry.appliedAt).toBe(testCase.appliedAt)
       expect(entry.repoDisplayName).toBe(testCase.repoDisplayName)
       expect(entry.version).toBe(testCase.version)
       expect(entry.labels).toEqual(testCase.labels)
       expect(entry.releaseSourceUrl).toContain('/releases/tag/')
-      expect(entry.body.startsWith('###')).toBeTruthy()
+      expect(entry.body).toContain('###')
     }
   })
 
-  test('skips non-SDK changelog posts even when they are in the candidate list', async () => {
+  test('loads eligible release entries and skips non-release posts', async () => {
     const entries = await loadEligibleChangelogEntries({
       repoPath: REPO_ROOT,
       contentPaths: [
+        'content/2026/01-05-box-ui-elements-v2600-released.md',
         'content/2026/04-01-box-java-sdk-v1070-released.md',
         'content/2026/04-02-new-ai-models.md',
         'content/2026/04-01-box-ios-sdk-1060-released.md'
@@ -70,6 +88,7 @@ describe('Mintlify changelog parsing', () => {
     })
 
     expect(entries.map((entry) => entry.contentPath)).toEqual([
+      'content/2026/01-05-box-ui-elements-v2600-released.md',
       'content/2026/04-01-box-ios-sdk-1060-released.md',
       'content/2026/04-01-box-java-sdk-v1070-released.md'
     ])

--- a/code/tests/mintlifySync/converter.test.js
+++ b/code/tests/mintlifySync/converter.test.js
@@ -116,4 +116,16 @@ describe('convertReleaseToMintlifyEntry', () => {
       'snippets/changelog/2026/04-01-box-windows-sdk-v1080-released.mdx'
     )
   })
+
+  test('converts real Box UI Elements changelog entries', async () => {
+    const entry = await readParsedEntry('content/2026/01-05-box-ui-elements-v2600-released.md')
+    const result = convertReleaseToMintlifyEntry(entry)
+
+    expect(result.componentName).toBe('BoxUiElementsV2600Released_2026_01_05')
+    expect(result.filePath).toBe(
+      'snippets/changelog/2026/01-05-box-ui-elements-v2600-released.mdx'
+    )
+    expect(result.mdxContent).toContain('tags={["Frontend","UI Elements"]}')
+    expect(result.mdxContent).toContain('## Box UI Elements `v26.0.0` released')
+  })
 })

--- a/code/tests/mintlifySync/index.test.js
+++ b/code/tests/mintlifySync/index.test.js
@@ -100,7 +100,7 @@ describe('runMintlifySync', () => {
     const indexContent = await fs.readFile(path.join(tempDir, 'changelog/index.mdx'), 'utf8')
 
     expect(output.entries).toHaveLength(2)
-    expect(output.prTitle).toBe('Add changelog entries: 2 release entries')
+    expect(output.prTitle).toBe('Add changelog entries: 2 releases')
     expect(output.filePaths).toEqual([
       'snippets/changelog/2026/04-01-box-ios-sdk-v1060-released.mdx',
       'snippets/changelog/2026/04-01-box-windows-sdk-v1080-released.mdx'

--- a/code/tests/mintlifySync/index.test.js
+++ b/code/tests/mintlifySync/index.test.js
@@ -60,7 +60,33 @@ describe('runMintlifySync', () => {
     expect(await fs.readJson(outputPath)).toEqual(output)
   })
 
-  test('handles multiple SDK changelog files in a single run and ignores non-SDK posts', async () => {
+  test('writes Mintlify files for a real Box UI Elements changelog file', async () => {
+    const outputPath = path.join(tempDir, 'workflow-output-buie.json')
+    process.env.CHANGELOG_REPO_PATH = REPO_ROOT
+    process.env.CONTENT_PATHS = 'content/2026/01-05-box-ui-elements-v2600-released.md'
+    process.env.MINTLIFY_REPO_PATH = tempDir
+    process.env.MINTLIFY_SYNC_OUTPUT_PATH = outputPath
+
+    const output = await runMintlifySync()
+    const snippetPath = path.join(
+      tempDir,
+      'snippets/changelog/2026/01-05-box-ui-elements-v2600-released.mdx'
+    )
+    const indexContent = await fs.readFile(path.join(tempDir, 'changelog/index.mdx'), 'utf8')
+    const snippetContent = await fs.readFile(snippetPath, 'utf8')
+
+    expect(output.entries).toHaveLength(1)
+    expect(output.prTitle).toBe('Add changelog: Box UI Elements v26.0.0')
+    expect(snippetContent).toContain('## Box UI Elements `v26.0.0` released')
+    expect(snippetContent).toContain('tags={["Frontend","UI Elements"]}')
+    expect(indexContent).toContain(
+      'import BoxUiElementsV2600Released_2026_01_05 from "/snippets/changelog/2026/01-05-box-ui-elements-v2600-released.mdx";'
+    )
+    expect(indexContent).toContain('<BoxUiElementsV2600Released_2026_01_05 />')
+    expect(await fs.readJson(outputPath)).toEqual(output)
+  })
+
+  test('handles multiple release changelog files in a single run and ignores non-release posts', async () => {
     process.env.CHANGELOG_REPO_PATH = REPO_ROOT
     process.env.CONTENT_PATHS = [
       'content/2026/04-02-new-ai-models.md',
@@ -74,7 +100,7 @@ describe('runMintlifySync', () => {
     const indexContent = await fs.readFile(path.join(tempDir, 'changelog/index.mdx'), 'utf8')
 
     expect(output.entries).toHaveLength(2)
-    expect(output.prTitle).toBe('Add changelog entries: 2 SDK releases')
+    expect(output.prTitle).toBe('Add changelog entries: 2 release entries')
     expect(output.filePaths).toEqual([
       'snippets/changelog/2026/04-01-box-ios-sdk-v1060-released.mdx',
       'snippets/changelog/2026/04-01-box-windows-sdk-v1080-released.mdx'
@@ -84,7 +110,7 @@ describe('runMintlifySync', () => {
     expect(indexContent).not.toContain('new-ai-models')
   })
 
-  test('returns a no-op workflow output when there are no eligible SDK entries', async () => {
+  test('returns a no-op workflow output when there are no eligible release entries', async () => {
     process.env.CHANGELOG_REPO_PATH = REPO_ROOT
     process.env.CONTENT_PATHS = 'content/2026/04-02-new-ai-models.md'
     process.env.MINTLIFY_REPO_PATH = tempDir


### PR DESCRIPTION
# Description

Updates the Mintlify changelog sync to include Box UI Elements release entries in addition to SDK releases. Box UI Elements releases are already imported into `box-developer-changelog` with the `ui-elements` label, but the Mintlify sync previously filtered them out because it only accepted entries labeled `sdks`.

This change also maps `ui-elements` to the proper `UI Elements` Mintlify tag, updates SDK-specific workflow/log copy to refer to release changelog entries, and adds parser, converter, and sync test coverage for Box UI Elements releases.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [ ] I have run `yarn test` and `yarn lint` to make sure my changes pass all
  linters and tests
- [x] I have pulled the latest changes from the upstream developer branch